### PR TITLE
Add startup log to Order Service

### DIFF
--- a/ticketing/orders/src/index.ts
+++ b/ticketing/orders/src/index.ts
@@ -7,6 +7,8 @@ import {ExpirationCompleteListener} from "./events/listeners/expiration-complete
 import {PaymentCreatedListener} from "./events/listeners/payment-created-listener";
 
 const start = async () => {
+    console.log("Starting Order Service");
+
     if (!process.env.JWT_KEY) {
         throw new Error('JWT_KEY must be defined');
     }


### PR DESCRIPTION
Added a console log message to indicate when the Order Service is starting. This provides clearer visibility into service initialization during development or debugging.